### PR TITLE
Implement a multi-step version of the results site

### DIFF
--- a/scraping_site/data_api.py
+++ b/scraping_site/data_api.py
@@ -21,14 +21,16 @@ def get_candidate_info(candidate_name):
             if result['candidate'] == candidate_name), None)
 
 
-def get_years_offices():
+def get_years_offices(year=None):
     years = set()
     offices = set()
 
     with open(RESULTS_PATH) as f:
         for result in csv.DictReader(f):
-            years.add(result['year'])
-            offices.add(result['office'])
+            if (year is None or
+                    (year is not None and result['year'] == str(year))):
+                years.add(result['year'])
+                offices.add(result['office'])
 
         return sorted(list(years)), sorted(list(offices))
 

--- a/scraping_site/form_with_post_request.py
+++ b/scraping_site/form_with_post_request.py
@@ -1,8 +1,29 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request
+
+from .data_api import get_race_results, get_years_offices
+
 
 bp = Blueprint('form_with_post_request', __name__)
 
-@bp.route('/5')
+
+@bp.route('/5', methods=['GET', 'POST'])
 def form_with_post_request():
-     # Same as form_with_url_params, but the URL doesn't change
-     return "TODO: Implement this"
+    year = request.values.get('year')
+    office = request.values.get('office')
+
+    if year is not None and office is not None:
+        results = get_race_results(year, office)
+
+        return render_template(
+            'simple-table-multistep.html',
+            results=results,
+            path=request.path
+        )
+
+    years, offices = get_years_offices(year=year)
+    return render_template(
+        'results-form-multistep.html',
+        year=year,
+        years=years,
+        offices=offices,
+    )

--- a/scraping_site/form_with_url_params.py
+++ b/scraping_site/form_with_url_params.py
@@ -21,6 +21,10 @@ def form_with_url_params():
 
     if year is not None and office is not None:
         results = get_race_results(year, office)
+
+        if len(results) == 0:
+            return render_template('error.html', year=year, office=office), 404
+
         page = int(request.args.get('page', 1))
         paginated, next_page, total_pages = paginate(results, page)
 

--- a/scraping_site/templates/base.html
+++ b/scraping_site/templates/base.html
@@ -38,6 +38,7 @@
     </nav>
     <div id="container">
         {% block content %}{% endblock %}
+        {% block aftercontent %}{% endblock %}
     </div>
 </body>
 

--- a/scraping_site/templates/error.html
+++ b/scraping_site/templates/error.html
@@ -5,9 +5,11 @@
 <div class="row">
     <div class="col-12 px-5 py-3">
         {% if candidate_name %}
-            <p>Whoops, we couldn't find {{candidate_name}}. Try looking for someone else!</p>
+        <p>Whoops, we couldn't find {{candidate_name}}. Try looking for someone else!</p>
+        {% elif year and office %}
+        <p>No results for {{ office }} in {{ year }}.</p>
         {% else %}
-            <p>Whoops, we couldn't find that page.</p>
+        <p>Whoops, we couldn't find that page.</p>
         {% endif %}
     </div>
 </div>

--- a/scraping_site/templates/results-form-multistep.html
+++ b/scraping_site/templates/results-form-multistep.html
@@ -5,7 +5,7 @@
         {% if year %}
         <h1>Select an office</h1>
         {% else %}
-        <h1>Select an election</h1>
+        <h1>Select a year</h1>
         {% endif %}
     </div>
 </div>
@@ -14,6 +14,8 @@
     <div class="col-3 px-5 py-3">
         <form method="post">
             {% if year %}
+            <input id="year" name="year" type="hidden" value="{{ year }}">
+
             <div class="form-group">
                 <label for="office">Office</label>
                 <select class="form-control" name="office" id="office">
@@ -22,7 +24,6 @@
                     {% endfor %}
                 </select>
             </div>
-            <input id="year" name="year" type="hidden" value="{{ year }}" />
             {% else %}
             <div class="form-group">
                 <label for="year">Year</label>
@@ -33,7 +34,6 @@
                 </select>
             </div>
             {% endif %}
-
 
             <button type="submit" class="btn btn-primary">Submit</button>
         </form>

--- a/scraping_site/templates/results-form.html
+++ b/scraping_site/templates/results-form.html
@@ -2,18 +2,13 @@
 {% block content %}
 <div class="row">
     <div class="col-12 px-5 py-3">
-        {% if year %}
-        <h1>Select an office</h1>
-        {% else %}
-        <h1>Select an election</h1>
-        {% endif %}
+        <h1>Select an election and office</h1>
     </div>
 </div>
 
 <div class="row">
     <div class="col-3 px-5 py-3">
-        <form method="post">
-            {% if year %}
+        <form>
             <div class="form-group">
                 <label for="office">Office</label>
                 <select class="form-control" name="office" id="office">
@@ -22,8 +17,7 @@
                     {% endfor %}
                 </select>
             </div>
-            <input id="year" name="year" type="hidden" value="{{ year }}" />
-            {% else %}
+
             <div class="form-group">
                 <label for="year">Year</label>
                 <select class="form-control" name="year" id="year">
@@ -32,8 +26,6 @@
                     {% endfor %}
                 </select>
             </div>
-            {% endif %}
-
 
             <button type="submit" class="btn btn-primary">Submit</button>
         </form>

--- a/scraping_site/templates/simple-table-multistep.html
+++ b/scraping_site/templates/simple-table-multistep.html
@@ -1,0 +1,9 @@
+{% extends "simple-table.html" %}
+
+{% block aftercontent %}
+<div class="row">
+    <div class="col-12 px-5 py-3">
+        <a href="{{ path }}">Back to results form</a>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Implement a mock election results site to scrape where the user must
select an election year and then an office through a multi-step form
submitted with an HTTP POST request. The values in the previous step of
the form are passed via hidden form inputs.

In order to provide a space for a link back to the main form page, I
added a new content block to the base template called `aftercontent`.

In order to only show offices for a particular year, I added a `year`
argument to the `get_years_offices()` function.

Addresses #15
https://github.com/asuozzo/nicar2019-scraping/issues/15